### PR TITLE
Extract pinMode into module and add test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "slash-command-prompter",
+  "version": "1.0.0",
+  "description": "The Slash Command Prompter is a browser extension designed to enhance productivity by allowing users to quickly insert predefined prompts into any text input field. It provides a user-friendly interface for managing and utilizing these prompts efficiently.",
+  "main": "background.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jest-chrome": "^0.7.1"
+  }
+}

--- a/pin.js
+++ b/pin.js
@@ -1,0 +1,23 @@
+function pinMode(id, modes, storage, showToast, renderModeDropdown) {
+  const index = modes.findIndex(m => m.id === id);
+
+  if (index > 0) {
+    // swap current mode with previous
+    const temp = modes[index];
+    modes[index] = modes[index - 1];
+    modes[index - 1] = temp;
+
+    storage.set({ modes }, function() {
+      showToast('模式已上移');
+      if (typeof renderModeDropdown === 'function') {
+        renderModeDropdown();
+      }
+    });
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { pinMode };
+} else {
+  window.pinMode = pinMode;
+}

--- a/popup.html
+++ b/popup.html
@@ -371,6 +371,7 @@
     </form>
   </div>
 
+  <script src="pin.js"></script>
   <script src="popup.js"></script>
   
   <div class="donate-container" style="text-align: center; margin-top: 20px; padding-top: 15px; border-top: 1px solid #eee;">

--- a/popup.js
+++ b/popup.js
@@ -103,7 +103,7 @@ document.addEventListener('DOMContentLoaded', function() {
       pinButton.innerHTML = '⬆︎';
       pinButton.addEventListener('click', function(e) {
         e.stopPropagation();
-        pinMode(mode.id);
+        pinMode(mode.id, modes, chrome.storage.local, showToast, renderModeDropdown);
       });
       
       // 添加悬停效果
@@ -974,23 +974,6 @@ document.addEventListener('DOMContentLoaded', function() {
         showToast('已经是当前模式的第一个提示词');
       }
     });
-  }
-
-  // 上移模式功能
-  function pinMode(id) {
-    const index = modes.findIndex(m => m.id === id);
-    
-    if (index > 0) {
-      // 交换当前模式与上一个模式的位置
-      const temp = modes[index];
-      modes[index] = modes[index - 1];
-      modes[index - 1] = temp;
-      
-      chrome.storage.local.set({ modes: modes }, function() {
-        showToast('模式已上移');
-        renderModeDropdown();
-      });
-    }
   }
 
   // 全局搜索结果显示

--- a/tests/pinMode.test.js
+++ b/tests/pinMode.test.js
@@ -1,0 +1,23 @@
+const { pinMode } = require('../pin');
+const chrome = require('jest-chrome');
+
+describe('pinMode', () => {
+  beforeEach(() => {
+    chrome.storage.local.set.mockClear();
+  });
+
+  test('moves mode up, writes to storage and shows toast', () => {
+    const modes = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+    const showToast = jest.fn();
+    const renderModeDropdown = jest.fn();
+
+    pinMode('b', modes, chrome.storage.local, showToast, renderModeDropdown);
+
+    expect(modes).toEqual([{ id: 'b' }, { id: 'a' }, { id: 'c' }]);
+    expect(chrome.storage.local.set).toHaveBeenCalled();
+    const callback = chrome.storage.local.set.mock.calls[0][1];
+    callback();
+    expect(chrome.storage.local.set).toHaveBeenCalledWith({ modes }, expect.any(Function));
+    expect(showToast).toHaveBeenCalledWith('模式已上移');
+  });
+});


### PR DESCRIPTION
## Summary
- extract `pinMode` into reusable module and hook popup to use it
- add Jest test verifying that `pinMode` swaps modes and shows toast
- set up basic npm config and ignore `node_modules`

## Testing
- `npm install --save-dev jest jest-chrome` *(fails: E403 Forbidden)*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891e5565288832ea920d945a79b239b